### PR TITLE
introduce ErrorBoundary for error catching

### DIFF
--- a/src/components/error-boundary/error-boundary.js
+++ b/src/components/error-boundary/error-boundary.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import './error-boundary.scss';
+
+export default class ErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            hasError: false,
+            error: null,
+            errorInfo: null,
+        };
+    }
+
+    componentDidCatch(error, errorInfo) {
+        this.setState({ hasError: true, error, errorInfo });
+    }
+
+    render() {
+        const errorMessage = this.state.error ? this.state.error.toString() : null;
+        const errorInfoMessage = this.state.errorInfo ? this.state.errorInfo.componentStack : null;
+
+        return this.state.hasError ? (
+            <section className="error-boundary">
+                <h3 className="error-boundary__title">{errorMessage}</h3>
+                <p className="error-boundary__text">{errorInfoMessage}</p>
+            </section>
+        ) : (
+            this.props.children
+        );
+    }
+}

--- a/src/components/error-boundary/error-boundary.scss
+++ b/src/components/error-boundary/error-boundary.scss
@@ -1,0 +1,15 @@
+.error-boundary {
+    padding: 0 16px;
+    background: rgba(222, 23, 56, .2);
+    color: rgba(222, 23, 56, 1);
+}
+
+.error-boundary__title {
+    padding-top: 16px;
+}
+
+.error-boundary__text {
+    padding-bottom: 16px;
+    white-space: pre-line;
+}
+

--- a/src/components/sandbox/sandbox.js
+++ b/src/components/sandbox/sandbox.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Icon from '../icon/icon';
 import Dialog from '../dialog/dialog';
+import ErrorBoundary from '../error-boundary/error-boundary';
 
 import './sandbox.scss';
 
@@ -12,14 +13,7 @@ export default class Sandbox extends React.Component {
         this.state = {
             isFullScreen: false,
             isVisible: true,
-            hasError: false,
-            error: null,
-            errorInfo: null,
         };
-    }
-
-    componentDidCatch(error, errorInfo) {
-        this.setState({ hasError: true, error, errorInfo });
     }
 
     render() {
@@ -66,29 +60,20 @@ export default class Sandbox extends React.Component {
                     </div>
                 </header>
 
-                {this.state.hasError ? (
-                    <pre>
-                        ### ERROR
-                        {JSON.stringify(this.state.error)}
-                        ### INFO
-                        {JSON.stringify(this.state.errorInfo)}
-                    </pre>
-                ) : (
-                    <React.Fragment>
-                        {this.state.isVisible && (
-                            <div className="styleguide-sandbox__content js-styleguide-sandbox__content">
-                                {this.props.children}
-                            </div>
-                        )}
+                <ErrorBoundary>
+                    {this.state.isVisible && (
+                        <div className="styleguide-sandbox__content js-styleguide-sandbox__content">
+                            {this.props.children}
+                        </div>
+                    )}
 
-                        <Dialog
-                            isOpened={this.state.isFullScreen}
-                            onClose={() => this.setState({ isFullScreen: false })}
-                            title={this.props.title}
-                            content={this.props.children}
-                        />
-                    </React.Fragment>
-                )}
+                    <Dialog
+                        isOpened={this.state.isFullScreen}
+                        onClose={() => this.setState({ isFullScreen: false })}
+                        title={this.props.title}
+                        content={this.props.children}
+                    />
+                </ErrorBoundary>
             </section>
         );
     }


### PR DESCRIPTION
Before during compilation of components we had unreadable one-line message which started JSON.stringify(this.state.error), which is aways equals to '{}' and long stack-trace in one line too , if we had mistake in code.

Now we see detailed message with multi-lined stack-trace.

some references:

- https://reactjs.org/docs/error-boundaries.html
- https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Error
