### PR TITLE
return TS-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Changelog
 
-## v0.0.34-alpha.2
-* Remove unused loader
-    * `ts-loader`
+## v0.0.34-alpha.3
 * Add `cache-loader` for speeding up the following builds, not in use with `--buildDir` param
 * Remove unused dependencies
     * `react-svg-loader`
     * `raw-loader`
-    * `ts-loader`
     * `resolve-url-loader`
     * `react-arc`
     * `react-native-svg-web`

--- a/get-webpack-config.js
+++ b/get-webpack-config.js
@@ -171,6 +171,16 @@ module.exports = function getWebpackConfig({
                             tsConfigPath: tsConfigPath,
                         },
                     },
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            configFile: tsConfigPath,
+                            happyPackMode: true,
+                            compilerOptions: {
+                                noEmit: false,
+                            },
+                        },
+                    },
                 ]),
             }),
         ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badoo-styleguide",
-  "version": "0.0.34-alpha.2",
+  "version": "0.0.34-alpha.3",
   "description": "Badoo styleguide used to develop UI components for the Web and React Native",
   "author": "badoo",
   "license": "MIT",
@@ -37,6 +37,7 @@
     "react-hot-loader": "4.8.0",
     "sass-loader": "7.1.0",
     "style-loader": "0.23.1",
+    "ts-loader": "6.2.1",
     "typescript": "3.4.5",
     "webpack": "4.29.6",
     "webpack-cli": "3.2.3",


### PR DESCRIPTION
In order to keep consumer's config file less as simple as possible, we return ts-loader in internal styleguide's config