### PR TITLE
remove happyHack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.0.38
+
+* Add `getLoadersForComponents` to help set loaders in config of webpack before props extraction from react-components
+* Removed `happy-hack` due to low impact on speed
+
 ## v0.0.37
 
 * Add reset for internal css styles of styleguide via `noDefaultGlobalStyles`, `noDefaultStyleguideStyles` ,`noDefaultNormalize`

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ module.exports = {
     },
 
     /**
-     * This function allows to set up global objects 
+     * This function allows to set up global objects
      * in browser environment
      * @optional
      */
@@ -181,6 +181,16 @@ module.exports = {
             jsLoader: path.resolve(cwd, 'src'),
             tsLoader: /src/,
         };
+    },
+
+    /**
+     * Returns the webpack loaders list for usage before component props eevaluation
+     * @param {string} path - The "path" node module to help you resolve any paths
+     * @returns Array<Object, string>
+     */
+
+    getLoadersForComponents({ path }) {
+        return ['babel-loader'];
     },
 
     /**

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ const ourWebpackConfig = getWebpackConfig({
     getComponentRoots: config.getComponentRoots,
     getSectionComponents: config.getSectionComponents,
     getExceptionForLoaders: config.getExceptionForLoaders,
+    getLoadersForComponents: config.getLoadersForComponents,
     getLoaderForModule: config.getLoaderForModule,
     tsConfigPath: path.resolve(process.cwd(), './tsconfig.json'),
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badoo-styleguide",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "Badoo styleguide used to develop UI components for the Web and React Native",
   "author": "badoo",
   "license": "MIT",
@@ -25,7 +25,6 @@
     "babel-loader": "8.0.5",
     "cache-loader": "^4.1.0",
     "file-loader": "3.0.1",
-    "happypack": "^5.0.1",
     "html-webpack-plugin": "3.2.0",
     "loader-utils": "^1.2.3",
     "metro-react-native-babel-preset": "^0.53.0",

--- a/src/app-global-styles.js
+++ b/src/app-global-styles.js
@@ -26,10 +26,6 @@ const useDefaultGlobalStyles = !config.noDefaultGlobalStyles;
 const useDefaultStyleguideStyles = !config.noDefaultStyleguideStyles;
 const useDefaultNormalize = !config.noDefaultNormalize;
 
-console.log(useDefaultGlobalStyles);
-console.log(useDefaultStyleguideStyles);
-console.log(useDefaultNormalize);
-
 const GlobalStyle = useDefaultGlobalStyles
     ? createGlobalStyle`
     ${useDefaultStyleguideStyles ? StyleGuideDefaultStyles : null}


### PR DESCRIPTION
* Add `getLoadersForComponents` to help set loaders in config of webpack before props extraction from react-components
* Removed `happy-hack` due to low impact on speed
