### PR TITLE
update to 0.0.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.0.43
+
+* Remove interfering css-styles from global scope
+* Return opportunity to set @babel/parser options to `react-docgen` for props-generation via `getBabelParserOptions`
+
 ## v0.0.42
 
 * Add `actionOnRender` - this function will apply provided actions during render of component

--- a/loaders/ts-component.js
+++ b/loaders/ts-component.js
@@ -39,8 +39,8 @@ module.exports = function(source) {
                 parserOptions: {
                     filename: '',
                     plugins: options.babelParserOptions
-                        ? ['jsx', ...options.babelParserOptions]
-                        : ['jsx'],
+                        ? ['typescript', 'jsx', ...options.babelParserOptions]
+                        : ['typescript', 'jsx'],
                 },
             }
         );
@@ -62,7 +62,7 @@ module.exports = function(source) {
                       const type = originalProp.type ? originalProp.type.name : key;
 
                       types[key] = {
-                          type,
+                          type: originalProp.tsType ? originalProp.tsType.name : type,
                           required: originalProp.required,
                           description: originalProp.description,
                       };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badoo-styleguide",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "Badoo styleguide used to develop UI components for the Web and React Native",
   "author": "badoo",
   "license": "MIT",

--- a/src/app-global-styles.js
+++ b/src/app-global-styles.js
@@ -9,14 +9,6 @@ const StyleGuideDefaultStyles = `
         box-sizing: border-box;
     }
 
-    body {
-        color: #6a6a6a;
-    }
-
-    h1 {
-        font-weight: 400;
-    }
-
     code {
         font-family: Consolas, "Liberation Mono", Menlo, monospace;
     }


### PR DESCRIPTION
* Remove interfering css-styles from global scope
* Return opportunity to set @babel/parser options to `react-docgen` for props-generation via `getBabelParserOptions`
