### PR TITLE
Update 0.0.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.0.44
 
-* fixed speed of build by setting up explicitly `transpileOnly` for `ts-loader`. It previously was set indireectly by [happypackmode](https://github.com/TypeStrong/ts-loader#happypackmode)
+* Fix speed of build by setting up explicitly `transpileOnly` for `ts-loader`. It previously was set indirectly by [happypackmode](https://github.com/TypeStrong/ts-loader#happypackmode)
 * Add `onlyCompileBundledFiles` to increase speed of `ts-loader`
 * Add `react-docgen-typescript` for fallback as solution for multiple import / export case in one module.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.0.44
+
+* fixed speed of build by setting up explicitly `transpileOnly` for `ts-loader`. It previously was set indireectly by [happypackmode](https://github.com/TypeStrong/ts-loader#happypackmode)
+* Add `onlyCompileBundledFiles` to increase speed of `ts-loader`
+* Add `react-docgen-typescript` for fallback as solution for multiple import / export case in one module.
+
 ## v0.0.43
 
 * Remove interfering css-styles from global scope

--- a/get-webpack-config.js
+++ b/get-webpack-config.js
@@ -57,6 +57,7 @@ module.exports = function getWebpackConfig({
         options: {
             componentRoots: getComponentRoots({ path }),
             babelParserOptions: getBabelParserOptions ? getBabelParserOptions() : undefined,
+            tsConfigPath,
         },
     };
 
@@ -69,6 +70,8 @@ module.exports = function getWebpackConfig({
         loader: 'ts-loader',
         options: {
             configFile: tsConfigPath,
+            transpileOnly: true,
+            onlyCompileBundledFiles: true,
             compilerOptions: {
                 noEmit: false,
             },

--- a/loaders/ts-component.js
+++ b/loaders/ts-component.js
@@ -1,8 +1,86 @@
 const path = require('path');
 const reactDocs = require('react-docgen');
+const reactDocsTS = require('react-docgen-typescript');
 const setParamsTypeDefinitionFromFunctionType = require('typescript-react-function-component-props-handler');
 const loaderUtils = require('loader-utils');
 const { isDebug } = require('../build-arguments');
+
+function setMeta(doc, fileName, resourcePath, source) {
+    const meta = {
+        name: doc.displayName,
+        description: doc.description,
+        filePath: resourcePath,
+        fileName,
+        fileNameWithoutPrefix: fileName
+            .split('.')
+            .slice(0, -1)
+            .join('.'),
+        propTypes: doc.props
+            ? Object.keys(doc.props).reduce(function(types, key) {
+                  const originalProp = doc.props[key];
+                  const type = originalProp.type ? originalProp.type.name : key;
+
+                  types[key] = {
+                      type: originalProp.tsType ? originalProp.tsType.name : type,
+                      required: originalProp.required,
+                      description: originalProp.description,
+                  };
+
+                  if (originalProp.defaultValue) {
+                      types[key].defaultValue = originalProp.defaultValue.value;
+                      types[key].type = originalProp.defaultValue.value
+                          .split('.')
+                          .slice(0, -1)
+                          .join('.');
+                  }
+
+                  return types;
+              }, {})
+            : null,
+    };
+    let results;
+
+    // Simple check to use if we are using ES6 or CJS
+    /* eslint-disable no-useless-escape */
+    if (source.indexOf('module.exports') !== -1) {
+        results = `${source}
+        module.exports.__meta = ${JSON.stringify(meta)};
+        module.exports.__dependencyResolver = require.context('./', true, /\.(j|t)sx?/);`;
+    } else if (/export\s+default/.test(source)) {
+        results = `${source}
+        ${doc.displayName}.__meta = ${JSON.stringify(meta)};
+        export const __dependencyResolver = require.context('./', true, /\.(j|t)sx?/);`;
+    } else {
+        results = `${source}
+        export const __meta = ${JSON.stringify(meta)};
+        export const __dependencyResolver = require.context('./', true, /\.(j|t)sx?/);`;
+    }
+    /* eslint-enable no-useless-escape */
+
+    return results;
+}
+
+function useGenericParser(source, options) {
+    return reactDocs.parse(
+        source,
+        null,
+        [setParamsTypeDefinitionFromFunctionType, ...reactDocs.defaultHandlers],
+        {
+            filename: '',
+            parserOptions: {
+                plugins: options.babelParserOptions
+                    ? ['typescript', 'jsx', ...options.babelParserOptions]
+                    : ['typescript', 'jsx'],
+            },
+        }
+    );
+}
+
+function useTSParser(resourcePath, tsConfigPath) {
+    return reactDocsTS.withCustomConfig(tsConfigPath).parse(resourcePath, {
+        filename: '',
+    });
+}
 
 module.exports = function(source) {
     if (this.cacheable) {
@@ -10,7 +88,6 @@ module.exports = function(source) {
     }
 
     const options = loaderUtils.getOptions(this);
-
     const componentRoots = options.componentRoots;
 
     let isComponent = false;
@@ -31,72 +108,33 @@ module.exports = function(source) {
     let results;
 
     try {
-        const doc = reactDocs.parse(
-            source,
-            null,
-            [setParamsTypeDefinitionFromFunctionType, ...reactDocs.defaultHandlers],
-            {
-                parserOptions: {
-                    filename: '',
-                    plugins: options.babelParserOptions
-                        ? ['typescript', 'jsx', ...options.babelParserOptions]
-                        : ['typescript', 'jsx'],
-                },
-            }
-        );
-
+        const doc = useGenericParser(source, options);
         const fileName = path.basename(this.resourcePath);
 
-        const meta = {
-            name: doc.displayName,
-            description: doc.description,
-            filePath: this.resourcePath,
-            fileName,
-            fileNameWithoutPrefix: fileName
-                .split('.')
-                .slice(0, -1)
-                .join('.'),
-            propTypes: doc.props
-                ? Object.keys(doc.props).reduce(function(types, key) {
-                      const originalProp = doc.props[key];
-                      const type = originalProp.type ? originalProp.type.name : key;
-
-                      types[key] = {
-                          type: originalProp.tsType ? originalProp.tsType.name : type,
-                          required: originalProp.required,
-                          description: originalProp.description,
-                      };
-
-                      if (originalProp.defaultValue) {
-                          types[key].defaultValue = originalProp.defaultValue.value;
-                          types[key].type = originalProp.defaultValue.value
-                              .split('.')
-                              .slice(0, -1)
-                              .join('.');
-                      }
-
-                      return types;
-                  }, {})
-                : null,
-        };
-
-        // Simple check to use if we are using ES6 or CJS
-        /* eslint-disable no-useless-escape */
-        if (source.indexOf('module.exports') !== -1) {
-            results = `${source}
-            module.exports.__meta = ${JSON.stringify(meta)};
-            module.exports.__dependencyResolver = require.context('./', true, /\.(j|t)sx?/);`;
-        } else if (/export\s+default/.test(source)) {
-            results = `${source}
-            ${doc.displayName}.__meta = ${JSON.stringify(meta)};
-            export const __dependencyResolver = require.context('./', true, /\.(j|t)sx?/);`;
-        } else {
-            results = `${source}
-            export const __meta = ${JSON.stringify(meta)};
-            export const __dependencyResolver = require.context('./', true, /\.(j|t)sx?/);`;
-        }
-        /* eslint-enable no-useless-escape */
+        results = setMeta(doc, fileName, this.resourcePath, source);
     } catch (err) {
+        if (err.message === `No suitable component definition found.`) {
+            const tsConfigPath = options.tsConfigPath;
+            const docs = useTSParser(this.resourcePath, tsConfigPath);
+
+            if (docs && source && this.resourcePath) {
+                const fileName = path.basename(this.resourcePath);
+
+                if (!docs[0]) {
+                    return source;
+                }
+
+                let doc = docs[0];
+
+                doc.displayName =
+                    doc.displayName.charAt(0).toUpperCase() + doc.displayName.slice(1);
+
+                results = setMeta(doc, fileName, this.resourcePath, source);
+
+                return results;
+            }
+        }
+
         if (!/Multiple exported component definitions found/.test(err)) {
             const componentPath = this.resourcePath.replace(foundComponentRoot, '');
             console.warn(componentPath, isDebug ? err : err.message);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badoo-styleguide",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "Badoo styleguide used to develop UI components for the Web and React Native",
   "author": "badoo",
   "license": "MIT",
@@ -30,6 +30,7 @@
     "loader-utils": "^1.2.3",
     "metro-react-native-babel-preset": "^0.53.0",
     "react-docgen": "5.3.0",
+    "react-docgen-typescript": "^1.16.3",
     "react-hot-loader": "4.8.0",
     "sass-loader": "7.1.0",
     "style-loader": "0.23.1",


### PR DESCRIPTION
* fixed speed of build by setting up explicitly `transpileOnly` for `ts-loader`. It previously was set indirectly by [happypackmode](https://github.com/TypeStrong/ts-loader#happypackmode)
* Add `onlyCompileBundledFiles` to increase speed of `ts-loader`
* Add `react-docgen-typescript` for fallback as solution for multiple import / export case in one module.
