### PR TITLE
add support for HOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.0.50
+
+* Add support for `HOC` components (classes, React.components, React.pureComponents)
+
+## v0.0.49
+
+* Add test-coverage via `jest`, `react-test-render`, `enzyme` to 100%
+
 ## v0.0.48
 
 * Add improved size props for `styleguide-device-frame`

--- a/loaders/js-component.js
+++ b/loaders/js-component.js
@@ -31,9 +31,9 @@ module.exports = function(source) {
     let results;
 
     try {
-        const doc = reactDocs.parse(
+        let doc = reactDocs.parse(
             source,
-            null,
+            reactDocs.resolver.findAllComponentDefinitions,
             [setParamsTypeDefinitionFromFunctionType, ...reactDocs.defaultHandlers],
             {
                 parserOptions: {
@@ -44,6 +44,11 @@ module.exports = function(source) {
                 },
             }
         );
+        /* currently we support the approach for the UI-architeture
+        as 1 module - 1 component */
+        if (doc.length && doc.length > 0) {
+            doc = doc[0];
+        }
 
         const fileName = path.basename(this.resourcePath);
 
@@ -89,6 +94,7 @@ module.exports = function(source) {
         } else if (/export\s+default/.test(source)) {
             results = `${source}
             ${doc.displayName}.__meta = ${JSON.stringify(meta)};
+            export const __highOrderComponentInnerComponent = ${doc.displayName}
             export const __dependencyResolver = require.context('./', true, /\.(j|t)sx?/);`;
         } else {
             results = `${source}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badoo-styleguide",
-  "version": "0.0.48",
+  "version": "0.0.50",
   "description": "Badoo styleguide used to develop UI components for the Web and React Native",
   "author": "badoo",
   "license": "MIT",

--- a/src/app-wrapper.jsx
+++ b/src/app-wrapper.jsx
@@ -32,9 +32,7 @@ function processConfigSection({ section: { name, components = [] }, isSpecificat
 }
 
 function processConfigComponent({ component, sectionName, isSpecificationPath }) {
-    const meta =
-        component.default && component.default.__meta ? component.default.__meta : component.__meta;
-
+    const meta = setComponentMeta(component);
     const dependencyResolver = component.__dependencyResolver;
 
     if (!dependencyResolver || !meta) {
@@ -53,6 +51,31 @@ function processConfigComponent({ component, sectionName, isSpecificationPath })
         propTypes: meta.propTypes,
         tests,
     };
+}
+
+function setComponentMeta(component) {
+    let meta =
+        component.default && component.default.__meta ? component.default.__meta : component.__meta;
+
+    if (isComponentHOC(component)) {
+        meta = component.__highOrderComponentInnerComponent.__meta;
+    }
+
+    return meta;
+}
+
+/**
+ * curently we support:
+ * classes,
+ * React.Components,
+ * React.PureComponents
+ */
+function isComponentHOC(component) {
+    return (
+        component.__highOrderComponentInnerComponent &&
+        component.__highOrderComponentInnerComponent.name !== component.default.name &&
+        component.default.name === '_class'
+    );
 }
 
 function getTestConfiguration(testModules) {


### PR DESCRIPTION
Add some changes:

* HOC-components (classes, React.components, React.pureComponents) are supported
* use `findAllComponentDefinitions` instead of `findExportedComponentDefinition` in `react-docgen`
