### PR TITLE
update to 0.0.62 - add vrt styles to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.62
+
+* add `useStylesForVRT` to config - now we cover some flaky tests in VRT by css
+
 ## v0.0.61
 
 * Change image provider used for mocks via `getImageUrl` to up-to-date provider.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ module.exports = {
     noDefaultNormalize: false,
 
     /**
+     * Set it to true if you want to get rid of some common flacky tests in VRT
+     * @optional
+     */
+    useStylesForVRT: false,
+
+    /**
      * Min-width for the sandbox wrapper (number | string)
      * default – 320
      * @optional

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badoo-styleguide",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "Badoo styleguide used to develop UI components for the Web and React Native",
   "author": "badoo",
   "license": "MIT",

--- a/src/app-global-styles.js
+++ b/src/app-global-styles.js
@@ -14,15 +14,25 @@ const StyleGuideDefaultStyles = `
     }
 `;
 
+const visualRegressionImprovedStyles = `
+    input,
+    textarea {
+        caret-color: transparent !important;
+    }
+`;
+
 const useDefaultGlobalStyles = !config.noDefaultGlobalStyles;
 const useDefaultStyleguideStyles = !config.noDefaultStyleguideStyles;
 const useDefaultNormalize = !config.noDefaultNormalize;
+const useStylesForVRT = config.useStylesForVRT;
 
 const GlobalStyle = useDefaultGlobalStyles
     ? createGlobalStyle`
     ${useDefaultStyleguideStyles ? StyleGuideDefaultStyles : null}
 
     ${useDefaultNormalize ? normalize : null}
+
+    ${useStylesForVRT ? visualRegressionImprovedStyles : null}
 `
     : createGlobalStyle``;
 


### PR DESCRIPTION
For cases when we use `Badoo-Styleguide` for VRT, we need some adjustments for avoiding flaky-tests.