### PR TITLE
Add iframes to styleguide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.0.64
+
+* Add visual helper `styleguide-iframe` for using iframes inside styleguide.
+* Add `isIFrame` to `StyleguideDeviceFrame`. Now you can set content of this helper inside of iframe individially.
+* Add opportunity to set all `StyleguideDeviceFrames` content inside iframes in config by `setDeviceFramesAsIframes` to true.
+
 ## v0.0.63
 
 * Make `useStylesForVRT` work with switched off default global styles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.0.64
 
 * Add visual helper `styleguide-iframe` for using iframes inside styleguide.
-* Add `isIFrame` to `StyleguideDeviceFrame`. Now you can set content of this helper inside of iframe individially.
+* Add `isIframe` to `StyleguideDeviceFrame`. Now you can set content of this helper inside of iframe individially.
 * Add opportunity to set all `StyleguideDeviceFrames` content inside iframes in config by `setDeviceFramesAsIframes` to true.
 
 ## v0.0.63

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Add the following content to the file
 ```js
 module.exports = {
     /**
+     * Set it to true if you want to set all StyleguideDeviceFrame components as iframes
+     * @optional
+     */
+    setDeviceFramesAsIframes: false,
+    /**
      * Set it to true if your project is a React native project
      * @optional
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import { VisualHelpers } from './src/visual-helpers';
 declare const visualHelpers: VisualHelpers;
 
 const StyleguideCell = visualHelpers.StyleguideCell;
+const StyleguideFrame = visualHelpers.StyleguideFrame;
 const StyleguideDeviceFrame = visualHelpers.StyleguideDeviceFrame;
 const StyleguideDeviceRange = visualHelpers.StyleguideDeviceRange;
 const StyleguideGroup = visualHelpers.StyleguideGroup;
@@ -11,6 +12,7 @@ const getImageUrl = visualHelpers.getImageUrl;
 
 export {
     StyleguideCell,
+    StyleguideFrame,
     StyleguideDeviceFrame,
     StyleguideDeviceRange,
     StyleguideGroup,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badoo-styleguide",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "Badoo styleguide used to develop UI components for the Web and React Native",
   "author": "badoo",
   "license": "MIT",

--- a/src/visual-helpers/index.js
+++ b/src/visual-helpers/index.js
@@ -1,4 +1,5 @@
 const StyleguideCell = require('./styleguide-cell/styleguide-cell').default;
+const StyleguideFrame = require('./styleguide-iframe/styleguide-iframe').default;
 const StyleguideDeviceFrame = require('./styleguide-device-frame/styleguide-device-frame').default;
 const StyleguideDeviceRange = require('./styleguide-device-range/styleguide-device-range').default;
 const StyleguideGroup = require('./styleguide-group/styleguide-group').default;
@@ -7,6 +8,7 @@ const getImageUrl = require('./styleguide-static/styleguide-static');
 
 const visualHelpers = {
     StyleguideCell,
+    StyleguideFrame,
     StyleguideDeviceFrame,
     StyleguideDeviceRange,
     StyleguideGroup,

--- a/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.d.ts
+++ b/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.d.ts
@@ -19,6 +19,10 @@ export type StyleguideDeviceFrameProps = {
      * The elements to be inserted in the content block
      */
     children?: React.ReactNode;
+    /**
+     * To use a real iframe or not
+     */
+    isIframe?: boolean;
 };
 
 declare const StyleguideDeviceFrame: React.FunctionComponent<StyleguideDeviceFrameProps> & {

--- a/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.jsx
+++ b/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.jsx
@@ -21,12 +21,12 @@ const propTypes = {
     children: PropTypes.node,
     size: PropTypes.oneOf(Object.keys(SIZES)),
     legend: PropTypes.string,
-    isIFrame: PropTypes.bool,
+    isIframe: PropTypes.bool,
 };
 
 function StyleguideDeviceFrame(props) {
-    const { children, size, legend, isIFrame } = props;
-    const Wrapper = isIFrame || config.setDeviceFramesAsIframes ? StyleguideFrame : React.Fragment;
+    const { children, size, legend, isIframe } = props;
+    const Wrapper = isIframe || config.setDeviceFramesAsIframes ? StyleguideFrame : React.Fragment;
 
     return (
         <StyleguideCell {...MapSizeToDimensions[size]} border={true} legend={legend}>

--- a/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.jsx
+++ b/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import StyleguideCell from '../styleguide-cell/styleguide-cell';
+import StyleguideFrame from '../styleguide-iframe/styleguide-iframe';
+
+import config from '__GLOBAL__CONFIG__';
 
 const SIZES = {
     SMALL: 'SMALL',
@@ -18,14 +21,16 @@ const propTypes = {
     children: PropTypes.node,
     size: PropTypes.oneOf(Object.keys(SIZES)),
     legend: PropTypes.string,
+    isIFrame: PropTypes.bool,
 };
 
 function StyleguideDeviceFrame(props) {
-    const { children, size, legend } = props;
+    const { children, size, legend, isIFrame } = props;
+    const Wrapper = isIFrame || config.setDeviceFramesAsIframes ? StyleguideFrame : React.Fragment;
 
     return (
         <StyleguideCell {...MapSizeToDimensions[size]} border={true} legend={legend}>
-            {children}
+            <Wrapper>{children}</Wrapper>
         </StyleguideCell>
     );
 }

--- a/src/visual-helpers/styleguide-iframe/styleguide-iframe.d.ts
+++ b/src/visual-helpers/styleguide-iframe/styleguide-iframe.d.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export type StyleguideIFrameProps = {
+    /**
+     * The elements to be inserted in the content block
+     */
+    children: React.ReactNode;
+    /**
+     * Styles tags, which want to pass in iframe. By default we take all styles from the app
+     */
+    styleList?: React.ReactNode[];
+    /**
+     * Each iframe should have unique title
+     */
+    title?: string;
+};
+
+/**
+ * for fallback purposes we support properties of React.IframeHTMLAttributes<HTMLIFrameElement> too
+ */
+declare const StyleguideIFrame: React.FunctionComponent<StyleguideIFrameProps> &
+    React.IframeHTMLAttributes<HTMLIFrameElement>;
+
+export default StyleguideIFrame;

--- a/src/visual-helpers/styleguide-iframe/styleguide-iframe.jsx
+++ b/src/visual-helpers/styleguide-iframe/styleguide-iframe.jsx
@@ -6,6 +6,7 @@ import { createPortal } from 'react-dom';
 const IframeWrapper = styled.div`
     position: relative;
     display: block;
+    height: 100%;
 `;
 const IframeBlock = styled.iframe`
     position: absolute;
@@ -33,8 +34,12 @@ const StyleguideIFrame = React.memo(
         const mountNode = contentRef && contentRef.contentWindow.document.body;
 
         useEffect(() => {
-            if (contentRef) {
-                styleList.map(style => contentRef.contentWindow.document.head.appendChild(style));
+            if (contentRef && styleList) {
+                styleList.map(style => {
+                    const iframeNewStyleElement = style.cloneNode(true);
+
+                    contentRef.contentWindow.document.head.appendChild(iframeNewStyleElement);
+                });
             }
         });
 

--- a/src/visual-helpers/styleguide-iframe/styleguide-iframe.jsx
+++ b/src/visual-helpers/styleguide-iframe/styleguide-iframe.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { createPortal } from 'react-dom';
+
+const IframeWrapper = styled.div`
+    position: relative;
+    display: block;
+`;
+const IframeBlock = styled.iframe`
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+`;
+
+const propTypes = {
+    children: PropTypes.node,
+    styleList: PropTypes.arrayOf(PropTypes.node),
+    title: PropTypes.string,
+};
+
+const StyleguideIFrame = React.memo(
+    ({
+        children,
+        title = `iframe-${Date.now()}`,
+        styleList = [...document.querySelectorAll('style')],
+        ...props
+    }) => {
+        const [contentRef, setContentRef] = useState(null);
+        const mountNode = contentRef && contentRef.contentWindow.document.body;
+
+        useEffect(() => {
+            if (contentRef) {
+                styleList.map(style => contentRef.contentWindow.document.head.appendChild(style));
+            }
+        });
+
+        return (
+            <IframeWrapper>
+                <IframeBlock {...props} title={title} ref={setContentRef}>
+                    {mountNode && createPortal(React.Children.only(children), mountNode)}
+                </IframeBlock>
+            </IframeWrapper>
+        );
+    }
+);
+
+StyleguideIFrame.displayName = 'Frame';
+StyleguideIFrame.propTypes = propTypes;
+
+export default StyleguideIFrame;


### PR DESCRIPTION
Add iframes to visual helpers:

- as separate element
- as part of `StyleguideDeviceFrame` via prop `isIframe`.
- opportunity to set all StyleguideDeviceFrame as frames via `setDeviceFramesAsIframes`.