### PR TITLE
add fix for arrow functions tests compiled in typescript with target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.65
+
+* Add support for tsconfig option for test scenarios:
+
+```json
+    compilerOptions": {
+        "target": "ESNext",
+    }
+```
+
 ## v0.0.64
 
 * Add visual helper `styleguide-iframe` for using iframes inside styleguide.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badoo-styleguide",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "description": "Badoo styleguide used to develop UI components for the Web and React Native",
   "author": "badoo",
   "license": "MIT",

--- a/src/app-wrapper.jsx
+++ b/src/app-wrapper.jsx
@@ -85,12 +85,23 @@ function getTestConfiguration(testModules) {
                 // Filter out system stuff (__meta, __dependencyResolver)
                 // @todo make explicit
                 .filter(exportKey => exportKey.indexOf('__') === -1)
-                .map(exportKey => module[exportKey]);
+                .map(exportKey => {
+                    let Test = {
+                        name: module[exportKey].name,
+                        testCase: module[exportKey]
+                    }
+
+                    if (!Test.name) {
+                        Test.name = exportKey;
+                    }
+
+                    return Test;
+                });
             return list.concat(variations);
         }, [])
         .map(Test => ({
             name: Test.name,
-            Component: Test,
+            Component: Test.testCase,
         }));
 }
 


### PR DESCRIPTION
* Add support for tsconfig option for test scenarios:

```json
    compilerOptions": {
        "target": "ESNext",
    }
```