### PR TITLE
support es6 modules in bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 coverage/
 examples/
 .idea/
+__snapshots__/

--- a/get-babel-options.js
+++ b/get-babel-options.js
@@ -36,7 +36,12 @@ module.exports = function getBabelOptions({ isReactNative, getBabelConfig }) {
         {
             babelrc: false,
             presets: [
-                [require.resolve('@babel/preset-env')],
+                [
+                    require.resolve('@babel/preset-env'),
+                    {
+                        modules: false,
+                    },
+                ],
                 [
                     require.resolve('@babel/preset-react'),
                     {

--- a/package.json
+++ b/package.json
@@ -86,8 +86,8 @@
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
     "react": "^16.8.4",
-    "react-dom": "16.8.4",
-    "react-test-renderer": "^16.13.1"
+    "react-dom": "16.13.0",
+    "react-test-renderer": "16.13.0"
   },
   "husky": {
     "hooks": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,6 @@
+import HotIndex from './hot-index';
 import React from 'react';
 import * as ReactDom from 'react-dom';
-import HotIndex from './hot-index';
 
 ReactDom.render(<HotIndex />, getWrapperElement());
 

--- a/src/visual-helpers/index.d.ts
+++ b/src/visual-helpers/index.d.ts
@@ -5,15 +5,11 @@ import StyleguideGroup from './styleguide-group/styleguide-group';
 import StyleguidePlaceholder from './styleguide-placeholder/styleguide-placeholder';
 import getImageUrl from './styleguide-static/styleguide-static';
 
-export type VisualHelpers = {
-    StyleguideCell: typeof StyleguideCell;
-    StyleguideDeviceFrame: typeof StyleguideDeviceFrame;
-    StyleguideDeviceRange: typeof StyleguideDeviceRange;
-    StyleguideGroup: typeof StyleguideGroup;
-    StyleguidePlaceholder: typeof StyleguidePlaceholder;
-    getImageUrl: typeof getImageUrl;
+export {
+    StyleguideCell,
+    StyleguideDeviceFrame,
+    StyleguideDeviceRange,
+    StyleguideGroup,
+    StyleguidePlaceholder,
+    getImageUrl,
 };
-
-declare const visualHelpers: VisualHelpers;
-
-export default visualHelpers;

--- a/src/visual-helpers/index.js
+++ b/src/visual-helpers/index.js
@@ -1,12 +1,12 @@
-const StyleguideCell = require('./styleguide-cell/styleguide-cell').default;
-const StyleguideFrame = require('./styleguide-iframe/styleguide-iframe').default;
-const StyleguideDeviceFrame = require('./styleguide-device-frame/styleguide-device-frame').default;
-const StyleguideDeviceRange = require('./styleguide-device-range/styleguide-device-range').default;
-const StyleguideGroup = require('./styleguide-group/styleguide-group').default;
-const StyleguidePlaceholder = require('./styleguide-placeholder/styleguide-placeholder').default;
-const getImageUrl = require('./styleguide-static/styleguide-static');
+import StyleguideCell from './styleguide-cell/styleguide-cell';
+import StyleguideFrame from './styleguide-iframe/styleguide-iframe';
+import StyleguideDeviceFrame from './styleguide-device-frame/styleguide-device-frame';
+import StyleguideDeviceRange from './styleguide-device-range/styleguide-device-range';
+import StyleguideGroup from './styleguide-group/styleguide-group';
+import StyleguidePlaceholder from './styleguide-placeholder/styleguide-placeholder';
+import getImageUrl from './styleguide-static/styleguide-static';
 
-const visualHelpers = {
+export {
     StyleguideCell,
     StyleguideFrame,
     StyleguideDeviceFrame,
@@ -15,5 +15,3 @@ const visualHelpers = {
     StyleguidePlaceholder,
     getImageUrl,
 };
-
-module.exports = visualHelpers;

--- a/src/visual-helpers/styleguide-cell/styleguide-cell.d.ts
+++ b/src/visual-helpers/styleguide-cell/styleguide-cell.d.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export type StyleguideCellProps = {
     /**

--- a/src/visual-helpers/styleguide-cell/styleguide-cell.jsx
+++ b/src/visual-helpers/styleguide-cell/styleguide-cell.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import View from '../styleguide-view';
 import Text from '../styleguide-text';

--- a/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.d.ts
+++ b/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.d.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 enum SIZES {
     SMALL = 'SMALL',

--- a/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.jsx
+++ b/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import StyleguideCell from '../styleguide-cell/styleguide-cell';
 import StyleguideFrame from '../styleguide-iframe/styleguide-iframe';

--- a/src/visual-helpers/styleguide-device-range/styleguide-device-range.d.ts
+++ b/src/visual-helpers/styleguide-device-range/styleguide-device-range.d.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export type StyleguideDeviceRangeProps = {
     /**

--- a/src/visual-helpers/styleguide-device-range/styleguide-device-range.jsx
+++ b/src/visual-helpers/styleguide-device-range/styleguide-device-range.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import StyleguideGroup from '../styleguide-group/styleguide-group';
 import StyleguideCell from '../styleguide-cell/styleguide-cell';

--- a/src/visual-helpers/styleguide-group/styleguide-group.d.ts
+++ b/src/visual-helpers/styleguide-group/styleguide-group.d.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export type StyleguideGroupProps = {
     /**

--- a/src/visual-helpers/styleguide-group/styleguide-group.jsx
+++ b/src/visual-helpers/styleguide-group/styleguide-group.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import View from '../styleguide-view';
 

--- a/src/visual-helpers/styleguide-iframe/styleguide-iframe.d.ts
+++ b/src/visual-helpers/styleguide-iframe/styleguide-iframe.d.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export type StyleguideIFrameProps = {
     /**

--- a/src/visual-helpers/styleguide-iframe/styleguide-iframe.jsx
+++ b/src/visual-helpers/styleguide-iframe/styleguide-iframe.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { createPortal } from 'react-dom';
@@ -24,9 +24,9 @@ const propTypes = {
 };
 
 function useForceUpdate() {
-    const [value, setValue] = useState(0);
+    const [value, setValue] = React.useState(0);
 
-    return () => setValue(value => ++value);
+    return () => setValue(value + 1);
 }
 
 const StyleguideIFrame = React.memo(
@@ -36,7 +36,7 @@ const StyleguideIFrame = React.memo(
         styleList = [...document.querySelectorAll('style')],
         ...props
     }) => {
-        const [contentRef, setContentRef] = useState(null);
+        const [contentRef, setContentRef] = React.useState(null);
         const forceUpdate = useForceUpdate();
         let mountNode = contentRef && contentRef.contentWindow.document.body;
 
@@ -51,7 +51,7 @@ const StyleguideIFrame = React.memo(
             forceUpdate();
         };
 
-        useEffect(() => {
+        React.useEffect(() => {
             if (contentRef && styleList) {
                 styleList.map(style => {
                     const iframeNewStyleElement = style.cloneNode(true);

--- a/src/visual-helpers/styleguide-placeholder/styleguide-placeholder.d.ts
+++ b/src/visual-helpers/styleguide-placeholder/styleguide-placeholder.d.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export type StyleguidePlaceholderProps = {
     /**

--- a/src/visual-helpers/styleguide-placeholder/styleguide-placeholder.jsx
+++ b/src/visual-helpers/styleguide-placeholder/styleguide-placeholder.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import View from '../styleguide-view';
 import Text from '../styleguide-text';

--- a/src/visual-helpers/styleguide-static/inlined-image/inlined-image.d.ts
+++ b/src/visual-helpers/styleguide-static/inlined-image/inlined-image.d.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export type InlinedImageProps = {
     text?: string;

--- a/src/visual-helpers/styleguide-static/styleguide-static.js
+++ b/src/visual-helpers/styleguide-static/styleguide-static.js
@@ -1,9 +1,9 @@
-const ReactDOMServer = require('react-dom/server');
-const InlinedImage = require('./inlined-image/inlined-image').default;
+import ReactDOMServer from 'react-dom/server';
+import InlinedImage from './inlined-image/inlined-image';
 
 const PROVIDER = 'https://via.placeholder.com';
 
-module.exports = function getImageUrl(options) {
+export default function getImageUrl(options) {
     const { width = 200, height, color, text, inlined = true } = options;
 
     if (inlined) {
@@ -34,4 +34,4 @@ module.exports = function getImageUrl(options) {
     }
 
     return `${PROVIDER}/${widthPart}${heightPart}${colorPart}${textPart}`;
-};
+}

--- a/src/visual-helpers/styleguide-text.jsx
+++ b/src/visual-helpers/styleguide-text.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 const Text = props => <span {...props} />;
 

--- a/src/visual-helpers/styleguide-view.jsx
+++ b/src/visual-helpers/styleguide-view.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 const View = props => <div {...props} />;
 


### PR DESCRIPTION
From now on we don't transpile by default modules to es5. It can be overrided back in babelrc if needed.