### PR TITLE
add reset icon for search field + move sidebar close icon to the left to prevent confusing

### DIFF
--- a/src/__tests__/__snapshots__/app-view.test.js.snap
+++ b/src/__tests__/__snapshots__/app-view.test.js.snap
@@ -10,16 +10,16 @@ exports[`App-view generic tests When app is open 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
   <div
-    className="lcYIcA"
+    className="fLDHOp"
     onClick={[Function]}
   >
     <svg
@@ -65,9 +65,9 @@ exports[`App-view generic tests When app is open 1`] = `
         >
           <input
             autoComplete="off"
-            className="fIzlLk"
+            className="hWZHBM"
             placeholder="Search component name"
-            type="text"
+            type="search"
             value=""
           />
           <div
@@ -262,6 +262,7 @@ exports[`App-view generic tests When component is open 1`] = `
   -moz-appearance: none;
   appearance: none;
   outline: none;
+  background-size: cover;
 }
 
 .c10:focus {
@@ -286,6 +287,25 @@ exports[`App-view generic tests When component is open 1`] = `
 .c10:-ms-input-placeholder {
   color: #ccc;
   opacity: 1;
+}
+
+.c10::-webkit-search-cancel-button {
+  height: 24px;
+  width: 24px;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  background-image: url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M15 2.41L13.59 1 8 6.59 2.41 1 1 2.41 6.59 8 1 13.59 2.41 15 8 9.41 13.59 15 15 13.59 9.41 8z" fill="currentColor" /></svg>');
+  background-size: 12px 12px;
+  background-position: center;
+  background-repeat: no-repeat;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 .c11 {
@@ -565,8 +585,8 @@ exports[`App-view generic tests When component is open 1`] = `
   height: 24px;
   -webkit-transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
   transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
-  top: 18px;
-  left: 260px;
+  top: 16px;
+  left: 16px;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
@@ -680,11 +700,11 @@ exports[`App-view generic tests When component is open 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
@@ -737,7 +757,7 @@ exports[`App-view generic tests When component is open 1`] = `
             autoComplete="off"
             className="c10"
             placeholder="Search component name"
-            type="text"
+            type="search"
             value=""
           />
           <div
@@ -1177,6 +1197,7 @@ exports[`App-view generic tests When filter doesn\`t show components 1`] = `
   -moz-appearance: none;
   appearance: none;
   outline: none;
+  background-size: cover;
 }
 
 .c10:focus {
@@ -1201,6 +1222,25 @@ exports[`App-view generic tests When filter doesn\`t show components 1`] = `
 .c10:-ms-input-placeholder {
   color: #ccc;
   opacity: 1;
+}
+
+.c10::-webkit-search-cancel-button {
+  height: 24px;
+  width: 24px;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  background-image: url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M15 2.41L13.59 1 8 6.59 2.41 1 1 2.41 6.59 8 1 13.59 2.41 15 8 9.41 13.59 15 15 13.59 9.41 8z" fill="currentColor" /></svg>');
+  background-size: 12px 12px;
+  background-position: center;
+  background-repeat: no-repeat;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 .c11 {
@@ -1328,8 +1368,8 @@ exports[`App-view generic tests When filter doesn\`t show components 1`] = `
   height: 24px;
   -webkit-transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
   transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
-  top: 18px;
-  left: 260px;
+  top: 16px;
+  left: 16px;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
@@ -1420,11 +1460,11 @@ exports[`App-view generic tests When filter doesn\`t show components 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
@@ -1477,7 +1517,7 @@ exports[`App-view generic tests When filter doesn\`t show components 1`] = `
             autoComplete="off"
             className="c10"
             placeholder="Search component name"
-            type="text"
+            type="search"
             value="g"
           />
           <div
@@ -1613,6 +1653,7 @@ exports[`App-view generic tests When filter show components 1`] = `
   -moz-appearance: none;
   appearance: none;
   outline: none;
+  background-size: cover;
 }
 
 .c10:focus {
@@ -1637,6 +1678,25 @@ exports[`App-view generic tests When filter show components 1`] = `
 .c10:-ms-input-placeholder {
   color: #ccc;
   opacity: 1;
+}
+
+.c10::-webkit-search-cancel-button {
+  height: 24px;
+  width: 24px;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  background-image: url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M15 2.41L13.59 1 8 6.59 2.41 1 1 2.41 6.59 8 1 13.59 2.41 15 8 9.41 13.59 15 15 13.59 9.41 8z" fill="currentColor" /></svg>');
+  background-size: 12px 12px;
+  background-position: center;
+  background-repeat: no-repeat;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 .c11 {
@@ -1905,8 +1965,8 @@ exports[`App-view generic tests When filter show components 1`] = `
   height: 24px;
   -webkit-transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
   transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
-  top: 18px;
-  left: 260px;
+  top: 16px;
+  left: 16px;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
@@ -2020,11 +2080,11 @@ exports[`App-view generic tests When filter show components 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
@@ -2077,7 +2137,7 @@ exports[`App-view generic tests When filter show components 1`] = `
             autoComplete="off"
             className="c10"
             placeholder="Search component name"
-            type="text"
+            type="search"
             value="c"
           />
           <div
@@ -2488,6 +2548,7 @@ exports[`App-view generic tests When we open component from app 1`] = `
   -moz-appearance: none;
   appearance: none;
   outline: none;
+  background-size: cover;
 }
 
 .c10:focus {
@@ -2512,6 +2573,25 @@ exports[`App-view generic tests When we open component from app 1`] = `
 .c10:-ms-input-placeholder {
   color: #ccc;
   opacity: 1;
+}
+
+.c10::-webkit-search-cancel-button {
+  height: 24px;
+  width: 24px;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  background-image: url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M15 2.41L13.59 1 8 6.59 2.41 1 1 2.41 6.59 8 1 13.59 2.41 15 8 9.41 13.59 15 15 13.59 9.41 8z" fill="currentColor" /></svg>');
+  background-size: 12px 12px;
+  background-position: center;
+  background-repeat: no-repeat;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 .c11 {
@@ -2680,8 +2760,8 @@ exports[`App-view generic tests When we open component from app 1`] = `
   height: 24px;
   -webkit-transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
   transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
-  top: 18px;
-  left: 260px;
+  top: 16px;
+  left: 16px;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
@@ -2772,11 +2852,11 @@ exports[`App-view generic tests When we open component from app 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
@@ -2829,7 +2909,7 @@ exports[`App-view generic tests When we open component from app 1`] = `
             autoComplete="off"
             className="c10"
             placeholder="Search component name"
-            type="text"
+            type="search"
             value=""
           />
           <div

--- a/src/__tests__/__snapshots__/app.test.js.snap
+++ b/src/__tests__/__snapshots__/app.test.js.snap
@@ -10,16 +10,16 @@ exports[`App generic tests When app is is unmounted 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
   <div
-    className="sc-iUuytg lcYIcA"
+    className="sc-iUuytg fLDHOp"
     onClick={[Function]}
   >
     <svg
@@ -65,12 +65,12 @@ exports[`App generic tests When app is is unmounted 1`] = `
         >
           <input
             autoComplete="off"
-            className="sc-dlfnbm fIzlLk"
+            className="sc-dlfnbm hWZHBM"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="Search component name"
-            type="text"
+            type="search"
             value=""
           />
           <div
@@ -198,16 +198,16 @@ exports[`App generic tests When app is open 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
   <div
-    className="sc-iUuytg lcYIcA"
+    className="sc-iUuytg fLDHOp"
     onClick={[Function]}
   >
     <svg
@@ -253,12 +253,12 @@ exports[`App generic tests When app is open 1`] = `
         >
           <input
             autoComplete="off"
-            className="sc-dlfnbm fIzlLk"
+            className="sc-dlfnbm hWZHBM"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="Search component name"
-            type="text"
+            type="search"
             value=""
           />
           <div
@@ -386,16 +386,16 @@ exports[`App generic tests When app receive no sections 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
   <div
-    className="sc-iUuytg lcYIcA"
+    className="sc-iUuytg fLDHOp"
     onClick={[Function]}
   >
     <svg
@@ -441,12 +441,12 @@ exports[`App generic tests When app receive no sections 1`] = `
         >
           <input
             autoComplete="off"
-            className="sc-dlfnbm fIzlLk"
+            className="sc-dlfnbm hWZHBM"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="Search component name"
-            type="text"
+            type="search"
             value="s"
           />
           <div
@@ -515,16 +515,16 @@ exports[`App search tests When we clear search request 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
   <div
-    className="sc-iUuytg lcYIcA"
+    className="sc-iUuytg fLDHOp"
     onClick={[Function]}
   >
     <svg
@@ -570,12 +570,12 @@ exports[`App search tests When we clear search request 1`] = `
         >
           <input
             autoComplete="off"
-            className="sc-dlfnbm fIzlLk"
+            className="sc-dlfnbm hWZHBM"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="Search component name"
-            type="text"
+            type="search"
             value="comp"
           />
           <div
@@ -674,16 +674,16 @@ exports[`App search tests When we clear search request 2`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
   <div
-    className="sc-iUuytg lcYIcA"
+    className="sc-iUuytg fLDHOp"
     onClick={[Function]}
   >
     <svg
@@ -729,12 +729,12 @@ exports[`App search tests When we clear search request 2`] = `
         >
           <input
             autoComplete="off"
-            className="sc-dlfnbm fIzlLk"
+            className="sc-dlfnbm hWZHBM"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="Search component name"
-            type="text"
+            type="search"
             value=""
           />
           <div
@@ -862,16 +862,16 @@ exports[`App search tests When we search, we have results filtered 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
   <div
-    className="sc-iUuytg lcYIcA"
+    className="sc-iUuytg fLDHOp"
     onClick={[Function]}
   >
     <svg
@@ -917,12 +917,12 @@ exports[`App search tests When we search, we have results filtered 1`] = `
         >
           <input
             autoComplete="off"
-            className="sc-dlfnbm fIzlLk"
+            className="sc-dlfnbm hWZHBM"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="Search component name"
-            type="text"
+            type="search"
             value=""
           />
           <div
@@ -1050,16 +1050,16 @@ exports[`App search tests When we search, we have results filtered 2`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
   <div
-    className="sc-iUuytg lcYIcA"
+    className="sc-iUuytg fLDHOp"
     onClick={[Function]}
   >
     <svg
@@ -1105,12 +1105,12 @@ exports[`App search tests When we search, we have results filtered 2`] = `
         >
           <input
             autoComplete="off"
-            className="sc-dlfnbm fIzlLk"
+            className="sc-dlfnbm hWZHBM"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
             placeholder="Search component name"
-            type="text"
+            type="search"
             value="comp"
           />
           <div

--- a/src/__tests__/components/app-view/__snapshots__/app-view.test.js.snap
+++ b/src/__tests__/components/app-view/__snapshots__/app-view.test.js.snap
@@ -85,8 +85,8 @@ exports[`AppView tests: AppView handleKeyDown test 1`] = `
   height: 24px;
   -webkit-transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
   transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
-  top: 18px;
-  left: 260px;
+  top: 16px;
+  left: 16px;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
@@ -203,11 +203,11 @@ exports[`AppView tests: AppView handleKeyDown test 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
@@ -349,8 +349,8 @@ exports[`AppView tests: AppView render 1`] = `
   height: 24px;
   -webkit-transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
   transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
-  top: 18px;
-  left: 260px;
+  top: 16px;
+  left: 16px;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
@@ -435,11 +435,11 @@ exports[`AppView tests: AppView render 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>
@@ -581,8 +581,8 @@ exports[`AppView tests: AppView sidebar visibility toggled 1`] = `
   height: 24px;
   -webkit-transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
   transition: all 0.2s cubic-bezier(0.34,1.56,0.64,1);
-  top: 18px;
-  left: 260px;
+  top: 16px;
+  left: 16px;
   -webkit-transform: scale(1);
   -ms-transform: scale(1);
   transform: scale(1);
@@ -667,11 +667,11 @@ exports[`AppView tests: AppView sidebar visibility toggled 1`] = `
   >
     <svg
       id="open"
-      viewBox="0 0 20 15"
+      viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z"
+        d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z"
       />
     </svg>
   </div>

--- a/src/__tests__/components/search-field/__snapshots__/search-field.test.js.snap
+++ b/src/__tests__/components/search-field/__snapshots__/search-field.test.js.snap
@@ -6,10 +6,10 @@ exports[`SearchField generic tests When we search 1`] = `
 >
   <input
     autoComplete="off"
-    className="fIzlLk"
+    className="hWZHBM"
     onChange={[Function]}
     placeholder="Search component name"
-    type="text"
+    type="search"
     value="comp"
   />
   <div

--- a/src/components/search-field/search-field.jsx
+++ b/src/components/search-field/search-field.jsx
@@ -26,6 +26,7 @@ const SearchFieldInput = styled.input`
     border: 1px solid #ccc;
     appearance: none;
     outline: none;
+    background-size: cover;
 
     &:focus {
         border-color: #000;
@@ -50,6 +51,21 @@ const SearchFieldInput = styled.input`
         color: ${SEARCH_FIELD_COLOR};
         opacity: 1;
     }
+
+    &::-webkit-search-cancel-button {
+        height: 24px;
+        width: 24px;
+        position: absolute;
+        right: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        cursor: pointer;
+        background-image: url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M15 2.41L13.59 1 8 6.59 2.41 1 1 2.41 6.59 8 1 13.59 2.41 15 8 9.41 13.59 15 15 13.59 9.41 8z" fill="currentColor" /></svg>');
+        background-size: 12px 12px;
+        background-position: center;
+        background-repeat: no-repeat;
+        appearance: none;
+    }
 `;
 
 const SearchFieldIcon = styled.div`
@@ -68,7 +84,7 @@ const SearchField = (props) => {
         <SearchFieldBlock>
             <SearchFieldInput
                 value={value}
-                type="text"
+                type="search"
                 onFocus={onFocus}
                 onChange={onChange}
                 onBlur={onBlur}

--- a/src/components/sidebar/sidebar-toggler.jsx
+++ b/src/components/sidebar/sidebar-toggler.jsx
@@ -34,8 +34,8 @@ const SidebarCloseIcon = styled.div`
         fill: currentColor;
     }
 
-    top: 18px;
-    left: 260px;
+    top: 16px;
+    left: 16px;
     transform: scale(${(props) => (props.isVisible ? 1 : 0.5)});
     opacity: ${(props) => (props.isVisible ? 1 : 0)};
     pointer-events: ${(props) => !props.isVisible && 'none'};
@@ -49,8 +49,8 @@ const SidebarCloseIcon = styled.div`
 const SidebarVisibilityToggler = (props) => (
     <React.Fragment>
         <SidebarOpenIcon isVisible={!props.isVisible} onClick={props.onClick}>
-            <svg id="open" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 15">
-                <path d="M0 1a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM0 7.03a1 1 0 011-1h18a1 1 0 110 2H1a1 1 0 01-1-1zM1 12.06a1 1 0 100 2h18a1 1 0 000-2H1z" />
+            <svg id="open" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M2 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm0 6a1 1 0 011-1h18a1 1 0 011 1 1 1 0 01-1 1H3a1 1 0 01-1-1zm1 5a1 1 0 00-1 1 1 1 0 001 1h18a1 1 0 001-1 1 1 0 00-1-1H3z" />
             </svg>
         </SidebarOpenIcon>
         <SidebarCloseIcon isVisible={props.isVisible} onClick={props.onClick}>


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes

Currently, when we're typing something in a search field in the sidebar, and want to erase it, there is no way to do it without selecting the text and deleting it with the keyboard. On the other hand, there is a 'cross' icon in the right top corner of the sidebar, really close to the search field, which is confusing - it closes the sidebar, not erases the text. 

My suggestion is to add native erase control, move the 'close sidebar' icon to the left, align it a bit with the hamburger icon. UX should be better after that

## Please, confirm that:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code requires separate test-version to release
