### PR TITLE
fix for styleguide cell extra div

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,5 @@ examples/
 .github
 __snapshots__/
 __tests__/
+src/__tests__/
 yarn-error.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.3
+
+* fix bug with `StyleguideCell` empty div wrapper by default.
+* fix for npm module.
+
 ## 2.0.2
 
 * add opportunity manually set font-size for legends/placeholders in visual tools.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badoo-styleguide",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Badoo styleguide is sandbox environment to develop  & document React UI components",
   "author": "badoo",
   "license": "MIT",

--- a/src/components/component/component.spec.jsx
+++ b/src/components/component/component.spec.jsx
@@ -169,3 +169,41 @@ export const SpecComponentDeviceRange = () => {
         </StyleguideDeviceRange>
     );
 };
+
+export const SpecComponentVirtualStyleguideCell = () => {
+    return (
+        <StyleguideCell height={300} backgroundColor="#ddeeff">
+            <StyleguideCell>
+                <StyleguidePlaceholder
+                    placeholder="Component takes all width of component"
+                    backgroundColor="#ffeedd"
+                />
+            </StyleguideCell>
+        </StyleguideCell>
+    );
+};
+
+export const SpecComponentRealDomStyleguideCell = () => {
+    return (
+        <StyleguideCell height="20vh" legend="Legend for component without div wrapper">
+            <StyleguidePlaceholder
+                placeholder="Component takes all width of component"
+                backgroundColor="#ffeedd"
+            />
+        </StyleguideCell>
+    );
+};
+
+export const SpecComponentRealDomStyleguideCellwithLegend = () => {
+    return (
+        <StyleguideCell
+            isVirtualElement={true}
+            legend="Legend for component, which is wrapped in div wrapper"
+        >
+            <StyleguidePlaceholder
+                placeholder="Component takes all width of component"
+                backgroundColor="#ffeedd"
+            />
+        </StyleguideCell>
+    );
+};

--- a/src/visual-helpers/styleguide-cell/styleguide-cell.d.ts
+++ b/src/visual-helpers/styleguide-cell/styleguide-cell.d.ts
@@ -20,7 +20,7 @@ export type StyleguideCellProps = {
     /**
      * height of cell for component's render
      */
-    height?: number;
+    height?: string | number;
     /**
      * If set to true - show visual border
      */
@@ -29,6 +29,10 @@ export type StyleguideCellProps = {
      * The elements to be inserted in the content block
      */
     children?: React.ReactNode;
+    /**
+     * The elements to be inserted in the content block
+     */
+    isVirtualElement?: boolean;
 };
 
 declare const StyleguideCell: React.FunctionComponent<StyleguideCellProps>;

--- a/src/visual-helpers/styleguide-cell/styleguide-cell.jsx
+++ b/src/visual-helpers/styleguide-cell/styleguide-cell.jsx
@@ -13,9 +13,10 @@ const propTypes = {
     fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     backgroundColor: PropTypes.string,
     width: PropTypes.number,
-    height: PropTypes.number,
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     border: PropTypes.bool,
     children: PropTypes.node,
+    isVirtualElement: PropTypes.bool,
 };
 
 function StyleguideCell(props) {
@@ -27,10 +28,11 @@ function StyleguideCell(props) {
         border,
         fontSize = config.legendFontSize ? config.legendFontSize : 10,
         children,
+        isVirtualElement,
     } = props;
 
     return (
-        <View>
+        <View isVirtualElement={!legend || isVirtualElement}>
             {legend ? (
                 <Text
                     style={{

--- a/src/visual-helpers/styleguide-cell/styleguide-cell.jsx
+++ b/src/visual-helpers/styleguide-cell/styleguide-cell.jsx
@@ -10,7 +10,7 @@ const Platform = {
 
 const propTypes = {
     legend: PropTypes.string,
-    fontSize: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
+    fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     backgroundColor: PropTypes.string,
     width: PropTypes.number,
     height: PropTypes.number,

--- a/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.jsx
+++ b/src/visual-helpers/styleguide-device-frame/styleguide-device-frame.jsx
@@ -21,7 +21,7 @@ const propTypes = {
     children: PropTypes.node,
     size: PropTypes.oneOf(Object.keys(SIZES)),
     legend: PropTypes.string,
-    fontSize: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
+    fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     isIframe: PropTypes.bool,
 };
 

--- a/src/visual-helpers/styleguide-device-range/styleguide-device-range.jsx
+++ b/src/visual-helpers/styleguide-device-range/styleguide-device-range.jsx
@@ -5,7 +5,7 @@ import StyleguideCell from '../styleguide-cell/styleguide-cell';
 
 const propTypes = {
     children: PropTypes.node,
-    fontSize: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
+    fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 function StyleguideDeviceRange(props) {

--- a/src/visual-helpers/styleguide-placeholder/styleguide-placeholder.d.ts
+++ b/src/visual-helpers/styleguide-placeholder/styleguide-placeholder.d.ts
@@ -24,7 +24,7 @@ export type StyleguidePlaceholderProps = {
     /**
      * height of cell for component's render
      */
-    height?: string;
+    height?: string | number;
     /**
      * If set to true - show visual border
      */

--- a/src/visual-helpers/styleguide-placeholder/styleguide-placeholder.jsx
+++ b/src/visual-helpers/styleguide-placeholder/styleguide-placeholder.jsx
@@ -6,7 +6,7 @@ import config from '__GLOBAL__CONFIG__';
 
 const propTypes = {
     width: PropTypes.string,
-    height: PropTypes.string,
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     backgroundColor: PropTypes.string,
     color: PropTypes.string,
     fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/src/visual-helpers/styleguide-placeholder/styleguide-placeholder.jsx
+++ b/src/visual-helpers/styleguide-placeholder/styleguide-placeholder.jsx
@@ -9,7 +9,7 @@ const propTypes = {
     height: PropTypes.string,
     backgroundColor: PropTypes.string,
     color: PropTypes.string,
-    fontSize: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
+    fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     placeholder: PropTypes.string,
 };
 
@@ -41,8 +41,6 @@ function StyleguidePlaceholder(props) {
                     fontFamily: 'monospace',
                     color: color || '#777',
                 }}
-                ellipsizeMode={'middle'}
-                numberOfLines={1}
             >
                 {placeholderText}
             </Text>

--- a/src/visual-helpers/styleguide-static/inlined-image/inlined-image.jsx
+++ b/src/visual-helpers/styleguide-static/inlined-image/inlined-image.jsx
@@ -2,14 +2,14 @@ import PropTypes from 'prop-types';
 
 const propTypes = {
     text: PropTypes.string,
-    width: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-    height: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-    color: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-    fontFamily: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-    fontSize: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-    fontWeight: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-    textColor: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-    letterSpacing: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    color: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    fontFamily: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    fontWeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    textColor: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    letterSpacing: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     dominantBaseline: PropTypes.oneOf([
         'auto',
         'text-bottom',

--- a/src/visual-helpers/styleguide-view.jsx
+++ b/src/visual-helpers/styleguide-view.jsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
 
-const View = (props) => <div {...props} />;
+const View = (props) => {
+    const { isVirtualElement, ...realProps } = props;
+
+    if (isVirtualElement) {
+        return <React.Fragment {...realProps} />;
+    }
+
+    return <div {...realProps} />;
+};
 
 export default View;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Proposed Changes

StyleguideCell no longer have extra div by default. Also small changes to types provided as well.
 
## Please, confirm that:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code requires separate test-version to release
