### PR TITLE
add public path for serving app & webpack assets via subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ module.exports = {
         ];
     },
 
+    /**
+     * This function sets public path for the app. It is useful for handling subdirectories
+     * in browser environment
+     * @optional
+     * @returns String
+     */
+    getPublicPath() {
+        return '/';
+    }
+
     // Return an array of all folders, where
     // we need to look for components
     getComponentRoots({ path }) {

--- a/__tests__/__snapshots__/styleguide.config.test.js.snap
+++ b/__tests__/__snapshots__/styleguide.config.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "applyBabelToTypescriptCode": true,
   "getComponentRoots": [Function],
   "getExceptionForLoaders": [Function],
+  "getPublicPath": [Function],
   "getSections": [Function],
   "getWebpackConfig": [Function],
   "hasResizableSandbox": false,

--- a/get-webpack-config.js
+++ b/get-webpack-config.js
@@ -41,6 +41,7 @@ const resolveComponentPathsFromComponentRoots = (components, getComponentRoots) 
 module.exports = function getWebpackConfig({
     buildDir,
     configPath,
+    publicPath,
     getSections,
     getComponentRoots,
     getExceptionForLoaders,
@@ -128,7 +129,7 @@ module.exports = function getWebpackConfig({
                 ? path.resolve(process.cwd(), buildDir)
                 : path.resolve(__dirname, 'dist'),
             filename: 'bundle.js',
-            publicPath: '/',
+            publicPath,
         },
         devServer: {
             clientLogLevel: isDebug ? 'info' : 'warning',

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -32,6 +32,10 @@ module.exports = {
         ];
     },
 
+    getPublicPath() {
+        return 'app';
+    },
+
     getComponentRoots({ path }) {
         const cwd = path.resolve(__dirname, '.');
 

--- a/webpack-server.js
+++ b/webpack-server.js
@@ -48,9 +48,13 @@ const tsConfigPath = config.tsConfigPath
     ? config.tsConfigPath
     : path.resolve(process.cwd(), './tsconfig.json');
 
+const publicPath = `/${
+    config.getPublicPath && typeof config.getPublicPath === 'function' ? config.getPublicPath() : ''
+}`;
 const ourWebpackConfig = getWebpackConfig({
     buildDir: args.buildDir,
     configPath,
+    publicPath,
     getSections: config.getSections,
     getComponentRoots: config.getComponentRoots,
     getExceptionForLoaders: config.getExceptionForLoaders,
@@ -95,6 +99,6 @@ if (isCompiling) {
         .use(hotMiddleware(compiler));
 
     server.listen(PORT, HOST, () => {
-        console.log(`Starting server on http://${HOST}:${PORT}`);
+        console.log(`Starting server on http://${HOST}:${PORT}${publicPath}`);
     });
 }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Proposed Changes

If we would like to serve results of Webpack build from specific path /  url, now we can set it via `getPublicPath `. However, it is optional and compatible with previous versions change

## Please, confirm that:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code requires separate test-version to release
